### PR TITLE
Fix file paths so images display on github.

### DIFF
--- a/samples/1.2 [Numeric] Regression with Synthetic Data.ipynb
+++ b/samples/1.2 [Numeric] Regression with Synthetic Data.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "In this example, we generate input data randomly with three features, x<sub>1</sub>, x<sub>2</sub> and x<sub>3</sub>. Our goal is to train a regression model that takes the input of the features and gives a prediction of the dependent variable, y. More specifically, we are training a linear model meaning that we expect that the conditional expectation of y is a linear combination of the given feautures, i.e. x<sub>1</sub>, x<sub>2</sub> and x<sub>3</sub>.\n",
     "\n",
-    "<img src=\"images\\1-3-1.png\" align = \"middle\"/>"
+    "<img src=\"images/1-3-1.png\" align = \"middle\"/>"
    ]
   },
   {

--- a/samples/3.1 [Plot] Visualize a pipeline.ipynb
+++ b/samples/3.1 [Plot] Visualize a pipeline.ipynb
@@ -619,7 +619,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"images\\pipeline-visualization_16_0.png\" align = \"middle\"/>"
+    "<img src=\"images/pipeline-visualization_16_0.png\" align = \"middle\"/>"
    ]
   },
   {


### PR DESCRIPTION
The images display correctly locally, but github has an issue with the backslashes.  Forward slashes work both on Windows and on github.