### PR TITLE
Added parameter to k-means algorithm in Image Classification example to achieve determinism

### DIFF
--- a/samples/2.6 [Image] Image Processing - Clustering.ipynb
+++ b/samples/2.6 [Image] Image Processing - Clustering.ipynb
@@ -519,7 +519,7 @@
    "source": [
     "# Creating full pipeline\n",
     "pca = PcaTransformer(rank = 600, columns = ['Relu_1']) # Add PCA to reduce dimensionality \n",
-    "kmeansplusplus = KMeansPlusPlus(n_clusters = 10, feature = ['Relu_1'])\n",
+    "kmeansplusplus = KMeansPlusPlus(n_clusters = 10, feature = ['Relu_1'], number_of_threads = 1)\n",
     "\n",
     "ppl = Pipeline([loader, resizer, pix_extractor, dnn_featurizer, pca, kmeansplusplus]) "
    ]


### PR DESCRIPTION
Fixes #24 .
After researching the root cause of the [Image Classification example](https://github.com/microsoft/NimbusML-Samples/blob/master/samples/2.6%20%5BImage%5D%20Image%20Processing%20-%20Clustering.ipynb), I discovered that there are three potential factors that affect the results of each run, that may change at each run. 

These are: 

- the seed provided to Pipeline

- the _number_of_threads_ variable provided to KMeans

- and the seed provided to PCATransformer.

There exist default values for the seed provided to Pipeline (seed = 42), and the seed provided to PCATransformer (seed = 0). However, by default, _number_of_threads_  is set to _Automatic_, which means this value may vary. 

In this fix, I have set _number_of_threads_ to 1 to achieve determinism at each run. This means that only 1 thread is used during one run.


